### PR TITLE
Upgrade image to work with latest Geyser MC build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bmoorman/ubuntu:focal
+FROM bmoorman/ubuntu:jammy
 
 ARG DEBIAN_FRONTEND=noninteractive \
     GEYSER_PORT=19132/udp
@@ -7,10 +7,10 @@ WORKDIR /var/lib/geyser
 
 RUN apt-get update \
  && apt-get install --yes --no-install-recommends \
-    default-jre-headless \
+    openjdk-17-jre-headless \
     vim \
     wget \
- && wget --quiet --directory-prefix /opt/geyser https://ci.nukkitx.com/job/GeyserMC/job/Geyser/job/master/lastSuccessfulBuild/artifact/bootstrap/standalone/target/Geyser.jar \
+ && wget --quiet --directory-prefix /opt/geyser https://ci.nukkitx.com/job/GeyserMC/job/Geyser/job/master/lastSuccessfulBuild/artifact/bootstrap/standalone/target/Geyser-Standalone.jar \
  && apt-get autoremove --yes --purge \
  && apt-get clean \
  && rm --recursive --force /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/geyser/start.sh
+++ b/geyser/start.sh
@@ -2,4 +2,4 @@
 exec $(which java) \
     -Xms${GEYSER_MIN_MEM:-1G} \
     -Xmx${GEYSER_MAX_MEM:-2G} \
-    -jar /opt/geyser/Geyser.jar
+    -jar /opt/geyser/Geyser-Standalone.jar


### PR DESCRIPTION
- Upgrade Ubuntu from Focal (20) to Jammy (22).
- Upgrade OpenJDK from 11 to 17.
- Update upstream Geyser MC download URL.

Resolves Issue #1 